### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,7 @@ jobs:
           sudo apt-get install -y libayatana-appindicator3-dev
           sudo apt-get install -y keybinder-3.0
           sudo apt-get install -y libnotify-dev
+          sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
           sudo apt-get install -y gstreamer-1.0
       - run: flutter pub get
       - run: flutter build linux


### PR DESCRIPTION
By adding the packages libgstreamer1.0-dev and libgstreamer-plugins-base1.0-dev, Flutter can now correctly compile Linux artifact
![Screenshot_20250327_215548](https://github.com/user-attachments/assets/b776d9a0-1059-4305-9992-b929a0479c5d)
