### PR TITLE
:bug: change -Werror to -Wextra

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
-  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE -Wall -Wextra)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
A deprecation warning from a third-party plugin **shouldn't** be treated as a fatal error that halts the entire build process. In my opinion, adding `-Werror` to the `linux/CMakeLists.txt` is a bit too aggressive, so I replaced it with `-Wextra` to receive more warning information without interrupting the build