### PR TITLE
Fix: v3 AppImage build error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           mkdir Solian.AppDir
           cp -r build/linux/x64/release/bundle/* Solian.AppDir
           cp -r buildtools/appimage_config/* Solian.AppDir
-          cp assets/icon/icon-padded.png Solian.AppDir
+          cp assets/icons/icon-padded.png Solian.AppDir
           sudo chmod +x buildtools/appimagetool-x86_64.AppImage
           sudo chmod +x Solian.AppDir/AppRun
           ./buildtools/appimagetool-x86_64.AppImage Solian.AppDir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           mkdir Solian.AppDir
           cp -r build/linux/x64/release/bundle/* Solian.AppDir
           cp -r buildtools/appimage_config/* Solian.AppDir
-          cp assets/icon/icon-light-radius.png Solian.AppDir
+          cp assets/icon/icon-padded.png Solian.AppDir
           sudo chmod +x buildtools/appimagetool-x86_64.AppImage
           sudo chmod +x Solian.AppDir/AppRun
           ./buildtools/appimagetool-x86_64.AppImage Solian.AppDir

--- a/buildtools/appimage_config/AppRun
+++ b/buildtools/appimage_config/AppRun
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+exec ./island

--- a/buildtools/appimage_config/Solian.desktop
+++ b/buildtools/appimage_config/Solian.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Name=Solian
+Exec=island %u
+Icon=icon-padded
+Categories=Network;


### PR DESCRIPTION
**Cause of Build Failure:**

It appears that the `buildtools` directory has not been properly updated to the `v3` branch. This directory contains two critical components:

1. `appimage_config/`
   (A directory containing the configuration files for building the AppImage application)

2. `appimagetool-x86_64.AppImage`
   (The main build tool binary)

In the "Build AppImage" workflow step, the following operations reference these resources:

* `cp -r buildtools/appimage_config/* Solian.AppDir`
  (Copies the configuration files into the temporary build directory)

* `./buildtools/appimagetool-x86_64.AppImage Solian.AppDir`
  (Performs the actual build process)

Without these files, the build cannot proceed.

Additionally, according to the workflow configuration, `assets/icons/icon-padded.png` is currently used as the desktop entry icon. If the primary developer has other preferences, this can be changed accordingly.
