### PR TITLE
[FIX] linux_firebase_guard: skip FirebaseMessaging calls on Linux

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -181,6 +181,9 @@ class IslandApp extends HookConsumerWidget {
     }
 
     useEffect(() {
+      if (!kIsWeb && Platform.isLinux) {
+        return null;
+      }
       const channel = MethodChannel('dev.solsynth.solian/notifications');
 
       Future<void> handleInitialLink() async {


### PR DESCRIPTION
Problem
In `main.dart` (line 58), Firebase is explicitly *not* initialized on Linux:

```dart
if (kIsWeb || !Platform.isLinux) {
  await Firebase.initializeApp(
    options: DefaultFirebaseOptions.currentPlatform,
  );
  FirebaseMessaging.onBackgroundMessage(
    _firebaseMessagingBackgroundHandler,
  );
}
```

However, in `Island.build` (line 207), the first `useEffect` unconditionally calls `FirebaseMessaging.instance.getInitialMessage()`:

```dart
// When the app is opened from a terminated state.
FirebaseMessaging.instance.getInitialMessage().then((message) {
  if (message != null) {
    handleMessage(message);
  }
});
```

On Linux, this leads to the following runtime error:

```
[core/no-app] No Firebase App '[DEFAULT]' has been created - call Firebase.initializeApp()
#0      MethodChannelFirebase.app (package:firebase_core_platform_interface/src/method_channel/method_channel_firebase.dart:192)
#1      Firebase.app (package:firebase_core/src/firebase.dart:79)
...
```

The application fails to start and only shows a white screen.
<img width="2240" height="1400" alt="Screenshot-20250809-192542" src="https://github.com/user-attachments/assets/37ea7033-f94c-4bbd-ace7-cb8d02e84e36" />

Solution
Add a platform guard in the first `useEffect` of `Island.build` to skip notification handling on Linux:

```dart
useEffect(() {
  if (!kIsWeb && Platform.isLinux) {
    return null;
  }
  const channel = MethodChannel('dev.solsynth.solian/notifications');
  ...
}, []);
```

After applying this change, the Linux client starts normally.
<img width="2240" height="1400" alt="Screenshot-20250810-005015" src="https://github.com/user-attachments/assets/ce94d4e3-9bcd-4cab-98dd-fa2b3060a007" />
