### PR TITLE
:bug: linux: guard FirebaseMessaging on unsupported platforms

### DIFF
--- a/lib/services/notify.dart
+++ b/lib/services/notify.dart
@@ -67,6 +67,9 @@ Future<void> subscribePushNotification(
   Dio apiClient, {
   bool detailedErrors = false,
 }) async {
+  if (Platform.isLinux){
+    return;
+  }
   await FirebaseMessaging.instance.requestPermission(
     alert: true,
     badge: true,


### PR DESCRIPTION
Problem
In main.dart (line 58), Firebase is explicitly not initialized on Linux:

```dart
if (kIsWeb || !Platform.isLinux) {
  await Firebase.initializeApp(
    options: DefaultFirebaseOptions.currentPlatform,
  );
  FirebaseMessaging.onBackgroundMessage(
    _firebaseMessagingBackgroundHandler,
  );
}
```

However, after the user logs in (`screens/auth/login.dart`),
`subscribePushNotification(apiClient)` is called unconditionally:

```dart
// Do post login tasks
final userNotifier = ref.read(userInfoProvider.notifier);
userNotifier.fetchUser().then((_) {
  final apiClient = ref.read(apiClientProvider);
  subscribePushNotification(apiClient);
  final wsNotifier = ref.read(websocketStateProvider.notifier);
  wsNotifier.connect();
  if (context.mounted) Navigator.pop(context, true);
});
```

In `services/notify.dart:70`, `subscribePushNotification` is implemented as:

```dart
Future<void> subscribePushNotification(
  Dio apiClient, {
  bool detailedErrors = false,
}) async {
  await FirebaseMessaging.instance.requestPermission(
    alert: true,
    badge: true,
    sound: true,
  );
  ...
}
```

Since Firebase is not initialized on Linux, this leads to:

```
[core/no-app] No Firebase App '[DEFAULT]' has been created - call Firebase.initializeApp()
#0      MethodChannelFirebase.app ...
#1      Firebase.app ...
#2      FirebaseMessaging.instance ...
#3      subscribePushNotification (package:island/services/notify.dart:70)
#4      _LoginCheckScreen.build.getToken.<anonymous closure> ...
```

**Symptom**
After login, the account page still shows the user as logged out and the client is unusable on Linux.

<img width="2240" height="1400" alt="Screenshot-20250810-131632" src="https://github.com/user-attachments/assets/0f53b9b1-706b-4a2e-8050-d35dc4f6bde6" />

**Solution**
Add a Linux platform guard to `subscribePushNotification` in `services/notify.dart`:

```dart
Future<void> subscribePushNotification(
  Dio apiClient, {
  bool detailedErrors = false,
}) async {
  if (Platform.isLinux) {
    return;
  }
  ...
}
```

After applying this change, the error disappears and the client works normally on Linux.

<img width="2240" height="1400" alt="Screenshot-20250810-132157" src="https://github.com/user-attachments/assets/1976a158-0aa0-4eb8-b3f7-5fdde21fbc89" />

