### PR TITLE
:bug: linux: guard FirebaseAnalyticsObserver when Firebase is not initialized

### DIFF
--- a/lib/route.dart
+++ b/lib/route.dart
@@ -1,6 +1,8 @@
+import 'dart:io' show Platform;
 import 'package:animations/animations.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:island/screens/about.dart';
@@ -69,15 +71,22 @@ Widget _tabPagesTransitionBuilder(
     child: child,
   );
 }
+bool get _supportsAnalytics =>
+    kIsWeb || Platform.isAndroid || Platform.isIOS;
 
 // Provider for the router
 final routerProvider = Provider<GoRouter>((ref) {
+  final observers = <NavigatorObserver>[];
+
+  if (_supportsAnalytics) {
+    final analytics = FirebaseAnalytics.instance;
+    observers.add(FirebaseAnalyticsObserver(analytics: analytics));
+  }
+
   return GoRouter(
     navigatorKey: rootNavigatorKey,
     initialLocation: '/',
-    observers: [
-      FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
-    ],
+    observers: observers,
     routes: [
       ShellRoute(
         navigatorKey: _shellNavigatorKey,


### PR DESCRIPTION
On Linux builds, the app was crashing because `GoRouter` unconditionally injected a `FirebaseAnalyticsObserver` with `FirebaseAnalytics.instance`.
Since Firebase is not initialized on Linux (and the plugin is not supported there), this caused:

```
[core/no-app] No Firebase App '[DEFAULT]' has been created - call Firebase.initializeApp()
```

### Fix

Add a platform guard in `route.dart` so that `FirebaseAnalyticsObserver` is only attached on platforms where Firebase Analytics is supported (Android, iOS, Web).
On Linux and other unsupported platforms, the observer list remains empty.

### Result

* Linux: app runs normally without crashes.
* Android/iOS/Web: analytics observer still attached and functional.