### PR TITLE
[FIX] tray: ensure Show Window works reliably on Linux/Wayland

### DIFF
--- a/lib/screens/tray_manager.dart
+++ b/lib/screens/tray_manager.dart
@@ -48,11 +48,12 @@ class TrayService {
   void handleAction(MenuItem item) {
     switch (item.key) {
       case 'show_window':
-        if (appWindow.isVisible) {
-          appWindow.restore();
-        } else {
-          appWindow.show();
-        }
+        () async {
+        appWindow.show();
+        appWindow.restore();
+        await Future.delayed(const Duration(milliseconds: 32));
+        appWindow.show();
+        }();
         break;
       case 'exit_app':
         appWindow.close();


### PR DESCRIPTION
Avoid relying on appWindow.isVisible, which is not trustworthy under
bitsdojo on Linux/Wayland. Instead, always run show → restore → show
sequence to guarantee window is re-mapped and raised.