### PR TITLE
[FIX] linux: correct Wayland window buffer mismatch by setAsFreameless()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -120,13 +120,25 @@ void main() async {
       windowButtonVisibility: true,
     );
     windowManager.waitUntilReadyToShow(windowOptions, () async {
+      final env = Platform.environment;
+      final isWayland = env.containsKey('WAYLAND_DISPLAY');
+
+      if (isWayland) {
+        try {
+          await windowManager.setAsFrameless();
+        } catch (e) {
+          debugPrint('[Wayland] setAsFrameless failed: $e');
+        }
+      }
+      await windowManager.setAsFrameless();
       await windowManager.setMinimumSize(defaultSize);
       await windowManager.show();
       await windowManager.focus();
       final opacity = prefs.getDouble(kAppWindowOpacity) ?? 1.0;
       await windowManager.setOpacity(opacity);
       talker.info(
-        "[SplashScreen] Desktop window is ready with size: ${initialSize.width}x${initialSize.height}",
+        "[SplashScreen] Desktop window is ready with size: ${initialSize.width}x${initialSize.height}"
+        "${isWayland ? " (Wayland frameless fix applied)" : ""}",
       );
     });
   }


### PR DESCRIPTION
Wayland (Hyprland, Sway, etc.) compositors misreport window buffer geometry when using transparent + hidden titlebar settings.

This causes Flutter to render outside the actual visible region and the debug banner to be cropped offscreen.

Calling windowManager.setAsFrameless() once after window creation forces compositor to reconfigure the surface and align buffer size with the visible client area.

No effect on X11, Windows, or macOS.