### PR TITLE
[FIX] linux: restrict setAsFrameless to Wayland only

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -130,7 +130,6 @@ void main() async {
           debugPrint('[Wayland] setAsFrameless failed: $e');
         }
       }
-      await windowManager.setAsFrameless();
       await windowManager.setMinimumSize(defaultSize);
       await windowManager.show();
       await windowManager.focus();


### PR DESCRIPTION
Apologies for the oversight in the previous merge — a redundant setAsFrameless() slipped outside the Wayland condition. 
This patch re-limits the call to Wayland only.