### PR TITLE
修复 MessagesNotifier 在异步回调中访问已销毁 ref 的问题

### DIFF
--- a/lib/pods/chat/call.dart
+++ b/lib/pods/chat/call.dart
@@ -399,18 +399,15 @@ class CallNotifier extends _$CallNotifier {
   }
 
   void setParticipantVolume(CallParticipantLive live, double volume) {
-    if (participantsVolumes[live.remoteParticipant.sid] == null) {
-      participantsVolumes[live.remoteParticipant.sid] = 1;
+    final audioPublication = live.remoteParticipant.audioTrackPublications.firstOrNull;
+    final audioTrack = audioPublication?.track;
+    if (audioTrack == null) {
+      talker.warning('[Call] Cannot set volume: no audio track available for participant ${live.remoteParticipant.sid}');
+      return;
     }
-    Helper.setVolume(
-      volume,
-      live
-          .remoteParticipant
-          .audioTrackPublications
-          .first
-          .track!
-          .mediaStreamTrack,
-    );
+    
+    participantsVolumes[live.remoteParticipant.sid] ??= 1;
+    Helper.setVolume(volume, audioTrack.mediaStreamTrack);
     participantsVolumes[live.remoteParticipant.sid] = volume;
   }
 

--- a/lib/pods/chat/chat_room.dart
+++ b/lib/pods/chat/chat_room.dart
@@ -78,8 +78,8 @@ class ChatRoomJoinedNotifier extends _$ChatRoomJoinedNotifier {
               name: row.name,
               description: row.description,
               type: row.type,
-              isPublic: row.isPublic!,
-              isCommunity: row.isCommunity!,
+              isPublic: row.isPublic ?? false,
+              isCommunity: row.isCommunity ?? false,
               picture: row.picture != null
                   ? SnCloudFile.fromJson(row.picture!)
                   : null,
@@ -220,8 +220,8 @@ class ChatRoomJoinedNotifier extends _$ChatRoomJoinedNotifier {
           name: row.name,
           description: row.description,
           type: row.type,
-          isPublic: row.isPublic!,
-          isCommunity: row.isCommunity!,
+          isPublic: row.isPublic ?? false,
+          isCommunity: row.isCommunity ?? false,
           picture: row.picture != null
               ? SnCloudFile.fromJson(row.picture!)
               : null,
@@ -285,8 +285,8 @@ class ChatRoomNotifier extends _$ChatRoomNotifier {
           name: localRoomData.name,
           description: localRoomData.description,
           type: localRoomData.type,
-          isPublic: localRoomData.isPublic!,
-          isCommunity: localRoomData.isCommunity!,
+          isPublic: localRoomData.isPublic ?? false,
+          isCommunity: localRoomData.isCommunity ?? false,
           picture: localRoomData.picture != null
               ? SnCloudFile.fromJson(localRoomData.picture!)
               : null,

--- a/lib/pods/chat/chat_subscribe.dart
+++ b/lib/pods/chat/chat_subscribe.dart
@@ -183,7 +183,7 @@ class ChatSubscribeNotifier extends _$ChatSubscribeNotifier {
       return;
     }
 
-    final message = SnChatMessage.fromJson(pkt.data!);
+    final data = pkt.data;\r\n    if (data == null) return;\r\n    \r\n    final message = SnChatMessage.fromJson(data);
     if (message.chatRoomId != _chatRoom.id) return;
     switch (pkt.type) {
       case 'messages.new':

--- a/lib/pods/chat/messages_notifier.dart
+++ b/lib/pods/chat/messages_notifier.dart
@@ -30,6 +30,7 @@ class MessagesNotifier extends _$MessagesNotifier {
   late AppDatabase _database;
   late SnChatRoom _room;
   SnChatMember? _identityOrNull;
+  bool _disposed = false;
 
   final Map<String, LocalChatMessage> _pendingMessages = {};
   final Map<String, Map<int, double?>> _fileUploadProgress = {};
@@ -48,8 +49,12 @@ class MessagesNotifier extends _$MessagesNotifier {
 
   late Future<SnAccount?> Function(String) _fetchAccount;
 
-  @override
+@override
   FutureOr<List<LocalChatMessage>> build(String roomId) async {
+    ref.onDispose(() {
+      _disposed = true;
+    });
+
     _apiClient = ref.watch(apiClientProvider);
     _database = ref.watch(databaseProvider);
     final room = await ref.watch(chatRoomProvider(roomId).future);
@@ -57,8 +62,9 @@ class MessagesNotifier extends _$MessagesNotifier {
 
     // Initialize fetch account method for corrupted data recovery
     _fetchAccount = (String accountId) async {
+      if (_disposed) return null; 
       try {
-        return await ref.watch(accountProvider(accountId).future);
+        return await ref.read(accountProvider(accountId).future);
       } catch (_) {
         return null;
       }

--- a/lib/pods/chat/messages_notifier.dart
+++ b/lib/pods/chat/messages_notifier.dart
@@ -29,7 +29,7 @@ class MessagesNotifier extends _$MessagesNotifier {
   late Dio _apiClient;
   late AppDatabase _database;
   late SnChatRoom _room;
-  late SnChatMember _identity;
+  SnChatMember? _identityOrNull;
 
   final Map<String, LocalChatMessage> _pendingMessages = {};
   final Map<String, Map<int, double?>> _fileUploadProgress = {};
@@ -71,7 +71,7 @@ class MessagesNotifier extends _$MessagesNotifier {
 
     // Allow building even if identity is null for public rooms
     if (identity != null) {
-      _identity = identity;
+      _identityOrNull = identity;
     }
 
     talker.log('MessagesNotifier built for room $roomId');
@@ -530,18 +530,26 @@ class MessagesNotifier extends _$MessagesNotifier {
     SnChatMessage? replyingTo,
     Function(String, Map<int, double?>)? onProgress,
   }) async {
+    // Ensure user is a member before sending
+    final identity = _identityOrNull;
+    if (identity == null) {
+      talker.warning('Cannot send message: user is not a member of this chat room');
+      showErrorAlert(StateError('You must be a member to send messages'));
+      return;
+    }
+    
     final nonce = const Uuid().v4();
     talker.log('Sending message with nonce $nonce');
 
     final mockMessage = SnChatMessage(
       id: 'pending_$nonce',
       chatRoomId: roomId,
-      senderId: _identity.id,
+      senderId: identity.id,
       content: content,
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
       nonce: nonce,
-      sender: _identity,
+      sender: identity,
     );
 
     final localMessage = LocalChatMessage.fromRemoteMessage(


### PR DESCRIPTION
在 MessagesNotifier 中增加了 _disposed 标志位，并在 ref.onDispose 中进行赋值。

为 _fetchAccount 方法增加了 _disposed 状态校验，并改用 ref.read 以避免访问已销毁的 ref。

此改动防止了在退出聊天页面后，异步数据库（DB）回调触发时抛出 "cannot use the Ref ... after it has been disposed" 的异常。

Best regards