### PR TITLE
🐛 fix no display end button while live stream started

### DIFF
--- a/lib/creators/screens/livestream/livestream_list.dart
+++ b/lib/creators/screens/livestream/livestream_list.dart
@@ -483,7 +483,7 @@ class _CreatorLivestreamItem extends ConsumerWidget {
                           ],
                         ),
                       ),
-                    if (status.toLowerCase() != 'active')
+                    if (stream.status != SnLiveStreamStatus.active)
                       PopupMenuItem(
                         value: 'start',
                         child: Row(
@@ -494,7 +494,7 @@ class _CreatorLivestreamItem extends ConsumerWidget {
                           ],
                         ),
                       ),
-                    if (status.toLowerCase() == 'active')
+                    if (stream.status == SnLiveStreamStatus.active)
                       PopupMenuItem(
                         value: 'end',
                         child: Row(


### PR DESCRIPTION
The original code incorrectly used  `status.toLowerCase() != 'active' ` to determine the live stream status, which caused the button state to not switch properly after localization was implemented. This issue was fixed by changing it to `stream.status == SnLiveStreamStatus.active`.