### PR TITLE
✨ Improve weather location fallback logic

### DIFF
--- a/lib/misc/dashboard/weather.dart
+++ b/lib/misc/dashboard/weather.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:dio/dio.dart';
 import 'package:island/shared/widgets/layouts/sheet_scaffold.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
 import 'package:open_meteo/open_meteo.dart';
@@ -310,6 +311,15 @@ class WeatherLocationException implements Exception {
 
 Future<({double latitude, double longitude, String label})>
 _resolveLocation() async {
+  try {
+    return await _resolveDeviceLocation();
+  } on WeatherLocationException {
+    return _resolveIpLocation();
+  }
+}
+
+Future<({double latitude, double longitude, String label})>
+_resolveDeviceLocation() async {
   final serviceEnabled = await Geolocator.isLocationServiceEnabled();
   if (!serviceEnabled) {
     throw WeatherLocationException('weatherLocationDisabled');
@@ -335,6 +345,46 @@ _resolveLocation() async {
     longitude: position.longitude,
     label: label,
   );
+}
+
+Future<({double latitude, double longitude, String label})>
+_resolveIpLocation() async {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'https://ipapi.co',
+      connectTimeout: const Duration(seconds: 8),
+      receiveTimeout: const Duration(seconds: 8),
+      headers: const {'User-Agent': 'Solian/Island Weather'},
+    ),
+  );
+
+  try {
+    final response = await dio.get<Map<String, dynamic>>('/json/');
+    final data = response.data;
+    if (data == null) {
+      throw StateError('weatherIpLocationEmpty');
+    }
+
+    final latitude = (data['latitude'] as num?)?.toDouble();
+    final longitude = (data['longitude'] as num?)?.toDouble();
+    if (latitude == null || longitude == null) {
+      throw StateError('weatherIpLocationMissingCoordinates');
+    }
+
+    final parts = [
+      data['city']?.toString().trim(),
+      data['region']?.toString().trim(),
+      data['country_name']?.toString().trim(),
+    ].whereType<String>().where((e) => e.isNotEmpty).toList();
+
+    final label = parts.isNotEmpty
+        ? parts.join(', ')
+        : '${latitude.toStringAsFixed(2)}°, ${longitude.toStringAsFixed(2)}°';
+
+    return (latitude: latitude, longitude: longitude, label: label);
+  } finally {
+    dio.close(force: true);
+  }
 }
 
 Future<String> _resolvePlaceName(double latitude, double longitude) async {


### PR DESCRIPTION
Update the weather location resolving logic to use IP-based geolocation when
device location cannot be obtained due to disabled location services, denied
permissions, or permanently denied permissions.

The weather card now tries to get the user's location from the device first.
If the location permission request fails, it falls back to the user's public IP
address to estimate the location, then uses the resolved coordinates to fetch
weather data.

Also improve location label handling by displaying city, region, and country
information when available, with coordinates as the final fallback.