### PR TITLE
[BLD] AppImage: ensure libquickjs_c_bridge_plugin.so existed

### DIFF
--- a/buildtools/build-appimage.sh
+++ b/buildtools/build-appimage.sh
@@ -1,5 +1,6 @@
 rm -rf Solian.AppDir
 mkdir Solian.AppDir
+cp linux/flutter/ephemeral/.plugin_symlinks/flutter_js/linux/shared/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
 cp -r build/linux/x64/release/bundle/* Solian.AppDir
 cp -r buildtools/appimage_config/* Solian.AppDir
 cp buildtools/icon-padded.png Solian.AppDir


### PR DESCRIPTION
Fixes #376 

透過直接複製構建過程中必然會被 `flutter_js` 下載的 `libquickjs_c_bridge_plugin.so` 到 `bundle/lib/`以解決庫缺失問題