### PR TITLE
[FIX] resolve runtime SIGSEGV caused by QuickJS and mujs symbol collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,13 @@ jobs:
           sudo apt-get install -y libsecret-1-dev
       - run: flutter pub get
       - run: flutter build linux --no-tree-shake-icons --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
+      - name: Build quickjs bridge plugin
+        run: |
+          cmake -B build_qjs -S third_party/quickjs_c_bridge/linux/ -DCMAKE_BUILD_TYPE=Release
+          cmake --build build_qjs
+          cp build_qjs/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
+          rm -rf build_qjs
+
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - run: flutter build linux --no-tree-shake-icons --dart-define=SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
       - name: Build quickjs bridge plugin
         run: |
-          cmake -B build_qjs -S third_party/quickjs_c_bridge/linux/ -DCMAKE_BUILD_TYPE=Release
+          cmake -B build_qjs -S linux/third_party/quickjs_c_bridge/linux/ -DCMAKE_BUILD_TYPE=Release
           cmake --build build_qjs
           cp build_qjs/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
           rm -rf build_qjs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/quickjs_c_bridge"]
+	path = third_party/quickjs_c_bridge
+	url = git@github.com:Texas0295/quickjs-c-bridge.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/quickjs_c_bridge"]
-	path = third_party/quickjs_c_bridge
+	path = linux/third_party/quickjs_c_bridge
 	url = git@github.com:Texas0295/quickjs-c-bridge.git

--- a/buildtools/build-appimage.sh
+++ b/buildtools/build-appimage.sh
@@ -1,6 +1,10 @@
 rm -rf Solian.AppDir
 mkdir Solian.AppDir
-cp linux/flutter/ephemeral/.plugin_symlinks/flutter_js/linux/shared/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
+
+cmake -B build_qjs -S third_party/quickjs_c_bridge/linux/ -DCMAKE_BUILD_TYPE=Release
+cmake --build build_qjs
+cp build_qjs/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
+
 cp -r build/linux/x64/release/bundle/* Solian.AppDir
 cp -r buildtools/appimage_config/* Solian.AppDir
 cp buildtools/icon-padded.png Solian.AppDir

--- a/buildtools/build-appimage.sh
+++ b/buildtools/build-appimage.sh
@@ -1,10 +1,5 @@
 rm -rf Solian.AppDir
 mkdir Solian.AppDir
-
-cmake -B build_qjs -S third_party/quickjs_c_bridge/linux/ -DCMAKE_BUILD_TYPE=Release
-cmake --build build_qjs
-cp build_qjs/libquickjs_c_bridge_plugin.so build/linux/x64/release/bundle/lib/
-
 cp -r build/linux/x64/release/bundle/* Solian.AppDir
 cp -r buildtools/appimage_config/* Solian.AppDir
 cp buildtools/icon-padded.png Solian.AppDir


### PR DESCRIPTION
fixes #376 

The prebuilt `libquickjs_c_bridge_plugin.so` provided by `flutter_js` exports public symbols for `js_malloc`, `js_realloc`, and `js_free`. When the application initializes `media_kit` (which loads `libmpv` and subsequently `libmujs`), a severe symbol collision occurs. The dynamic linker mistakenly routes QuickJS memory allocations to mujs functions, leading to an immediate segmentation fault (SIGSEGV) during runtime.

### Solution
Introduced the `quickjs_c_bridge` source as a submodule under `linux/third_party/` to build the plugin from source with proper symbol isolation.
Updated the GitHub Actions workflow to check out submodules and compile the bridge using CMake, ensuring symbols are properly restricted via visibility presets.
The compiled binary automatically overrides the flawed prebuilt file in the release bundle before packaging.